### PR TITLE
fix: Multiple callouts nested in blockquotes.

### DIFF
--- a/callout_test.go
+++ b/callout_test.go
@@ -79,6 +79,7 @@ func TestEmptyCallouts(t *testing.T) {
 `,
 	}, t)
 }
+
 func TestCalloutsWithContent(t *testing.T) {
 	var count = 0
 	count++
@@ -226,6 +227,73 @@ func TestExpandableCallouts(t *testing.T) {
  Open by default
 </summary>
 <p>Some content</p>
+</details>
+`,
+	}, t)
+}
+
+func TestMultipleCallouts(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts",
+		Markdown: `
+> [!info] First callout
+> Some content in the first callout
+
+> [!info] Second callout
+> Some content in the second callout
+`,
+		Expected: `<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ First callout
+</summary>
+<p>Some content in the first callout</p>
+</details>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ Second callout
+</summary>
+<p>Some content in the second callout</p>
+</details>
+`,
+	}, t)
+}
+
+func TestMultipleCalloutsWithBlockquote(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts with a blockquote in between",
+		Markdown: `
+> [!info] First callout
+> Some content in the first callout
+
+> All we are is dust in the wind...dude.
+> - Ted 
+
+> [!info] Second callout
+> Some content in the second callout
+`,
+		Expected: `<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ First callout
+</summary>
+<p>Some content in the first callout</p>
+</details>
+<blockquote>
+<p>All we are is dust in the wind...dude.</p>
+<ul>
+<li>Ted</li>
+</ul>
+</blockquote>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ Second callout
+</summary>
+<p>Some content in the second callout</p>
 </details>
 `,
 	}, t)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,18 +115,19 @@ func NewCalloutAstTransformer() parser.ASTTransformer {
 
 func (a *calloutAstTransformer) Transform(node *gast.Document, reader text.Reader, pc parser.Context) {
 
-	current := node.FirstChild()
-	// TODO: Extract the walking-replacing into a function to allow nested callouts (not used often..)
-	// check if current is of type gast.BlockQuote
-	for current != nil {
+	// walk top-level children — but capture next before we mutate the list
+	for current := node.FirstChild(); current != nil; {
+		next := current.NextSibling()
+
 		if current.Kind() == gast.KindBlockquote {
-			// check if the blockquote has a child of type callout
-			// if yes, then remove the blockquote and replace it with a callout
-			if current.FirstChild().Kind() == calloutAst.KindCallout {
-				// replace the blockquote with the callout
-				node.ReplaceChild(node, current, current.FirstChild())
+			firstChild := current.FirstChild()
+			if firstChild != nil && firstChild.Kind() == calloutAst.KindCallout {
+				// replace the blockquote with its callout child
+				// capture next before ReplaceChild (already done above)
+				node.ReplaceChild(node, current, firstChild)
 			}
 		}
-		current = current.NextSibling()
+
+		current = next
 	}
 }


### PR DESCRIPTION
This fixes an issue where callouts after the first one were incorrectly nested inside &lt;blockquote&gt; tags.

- Updated the AST transformer to properly handle sibling traversal when replacing blockquotes with callouts by capturing the next sibling before mutation.
- Add test cases for multiple callouts and callouts with blockquotes in between.