### PR TITLE
feat: nested callouts

### DIFF
--- a/callout_test.go
+++ b/callout_test.go
@@ -79,6 +79,7 @@ func TestEmptyCallouts(t *testing.T) {
 `,
 	}, t)
 }
+
 func TestCalloutsWithContent(t *testing.T) {
 	var count = 0
 	count++
@@ -226,6 +227,73 @@ func TestExpandableCallouts(t *testing.T) {
  Open by default
 </summary>
 <p>Some content</p>
+</details>
+`,
+	}, t)
+}
+
+func TestMultipleCallouts(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts",
+		Markdown: `
+> [!info] First callout
+> Some content in the first callout
+
+> [!info] Second callout
+> Some content in the second callout
+`,
+		Expected: `<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ First callout
+</summary>
+<p>Some content in the first callout</p>
+</details>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ Second callout
+</summary>
+<p>Some content in the second callout</p>
+</details>
+`,
+	}, t)
+}
+
+func TestMultipleCalloutsWithBlockquote(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts with a blockquote in between",
+		Markdown: `
+> [!info] First callout
+> Some content in the first callout
+
+> All we are is dust in the wind...dude.
+> - Ted 
+
+> [!info] Second callout
+> Some content in the second callout
+`,
+		Expected: `<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ First callout
+</summary>
+<p>Some content in the first callout</p>
+</details>
+<blockquote>
+<p>All we are is dust in the wind...dude.</p>
+<ul>
+<li>Ted</li>
+</ul>
+</blockquote>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ Second callout
+</summary>
+<p>Some content in the second callout</p>
 </details>
 `,
 	}, t)

--- a/callout_test.go
+++ b/callout_test.go
@@ -298,3 +298,97 @@ func TestMultipleCalloutsWithBlockquote(t *testing.T) {
 `,
 	}, t)
 }
+
+func TestNestedCallouts(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts",
+		Markdown: `
+>[!info] This is a callout
+>Text for the callout
+>>[!info] This is inside the outer callout
+>>More text inside the callout.
+		`,
+		Expected: `
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ This is a callout
+</summary>
+<p>Text for the callout</p>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ This is inside the outer callout
+</summary>
+<p>More text inside the callout.</p>
+</details>
+</details>
+		`,
+	}, t)
+}
+func TestNestedBlockquoteInsideCallout(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts",
+		Markdown: `
+>[!info] This is a callout
+>Text for the callout
+>>This is a blockquote inside the callout
+>
+>More text inside the callout.
+		`,
+		Expected: `
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ This is a callout
+</summary>
+<p>Text for the callout</p>
+<blockquote>
+<p>This is a blockquote inside the callout</p>
+</blockquote>
+<p>More text inside the callout.</p>
+</details>
+		`,
+	}, t)
+}
+func TestNestedBlockquoteInsideNestedCallout(t *testing.T) {
+	var count = 0
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Multiple callouts",
+		Markdown: `
+>[!info] This is a callout
+>Text for the callout
+>>[!info] This is an inner callout
+>>Text inside the inner clalout
+>>>This is a blockquote inside the callout
+>>
+>>More text inside the inner callout.
+>
+>More text inside the outer callout
+		`,
+		Expected: `
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ This is a callout
+</summary>
+<p>Text for the callout</p>
+<details class="callout" data-callout="info" open onclick="return false">
+<summary>
+ This is an inner callout
+</summary>
+<p>Text inside the inner clalout</p>
+<blockquote>
+<p>This is a blockquote inside the callout</p>
+</blockquote>
+<p>More text inside the inner callout.</p>
+</details>
+<p>More text inside the outer callout</p>
+</details>
+		`,
+	}, t)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,18 +115,19 @@ func NewCalloutAstTransformer() parser.ASTTransformer {
 
 func (a *calloutAstTransformer) Transform(node *gast.Document, reader text.Reader, pc parser.Context) {
 
-	current := node.FirstChild()
-	// TODO: Extract the walking-replacing into a function to allow nested callouts (not used often..)
-	// check if current is of type gast.BlockQuote
-	for current != nil {
+	// walk top-level children — but capture next before we mutate the list
+	for current := node.FirstChild(); current != nil; {
+		next := current.NextSibling()
+
 		if current.Kind() == gast.KindBlockquote {
-			// check if the blockquote has a child of type callout
-			// if yes, then remove the blockquote and replace it with a callout
-			if current.FirstChild().Kind() == calloutAst.KindCallout {
-				// replace the blockquote with the callout
-				node.ReplaceChild(node, current, current.FirstChild())
+			firstChild := current.FirstChild()
+			if firstChild != nil && firstChild.Kind() == calloutAst.KindCallout {
+				// replace the blockquote with its callout child
+				// capture next before ReplaceChild (already done above)
+				node.ReplaceChild(node, current, firstChild)
 			}
 		}
-		current = current.NextSibling()
+
+		current = next
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,19 +115,45 @@ func NewCalloutAstTransformer() parser.ASTTransformer {
 
 func (a *calloutAstTransformer) Transform(node *gast.Document, reader text.Reader, pc parser.Context) {
 
-	// walk top-level children — but capture next before we mutate the list
-	for current := node.FirstChild(); current != nil; {
-		next := current.NextSibling()
+	// Recursively walk every node and replace any blockquote whose first child
+	// is a Callout with the Callout node itself. When replacing, move the
+	// remaining children of the blockquote into the callout so nested callouts
+	// (>> style) are preserved.
+	var replace func(parent gast.Node)
+	replace = func(parent gast.Node) {
+		for current := parent.FirstChild(); current != nil; {
+			next := current.NextSibling()
 
-		if current.Kind() == gast.KindBlockquote {
-			firstChild := current.FirstChild()
-			if firstChild != nil && firstChild.Kind() == calloutAst.KindCallout {
-				// replace the blockquote with its callout child
-				// capture next before ReplaceChild (already done above)
-				node.ReplaceChild(node, current, firstChild)
+			if current.Kind() == gast.KindBlockquote {
+				firstChild := current.FirstChild()
+				if firstChild != nil && firstChild.Kind() == calloutAst.KindCallout {
+					// Move all siblings (children of the blockquote) after the first child
+					// into the callout so their content is not dropped when we replace
+					// the blockquote with the callout.
+					for child := firstChild.NextSibling(); child != nil; {
+						childNext := child.NextSibling()
+						// detach child from the blockquote
+						current.RemoveChild(current, child)
+						// append it to the callout
+						firstChild.AppendChild(firstChild, child)
+						child = childNext
+					}
+					// replace the blockquote with the callout (firstChild)
+					parent.ReplaceChild(parent, current, firstChild)
+					// continue traversal inside the moved callout
+					replace(firstChild)
+				} else {
+					// Recurse into the blockquote to find nested callouts deeper down
+					replace(current)
+				}
+			} else {
+				// Recurse into other node types as well to find blockquotes containing callouts at any depth
+				replace(current)
 			}
-		}
 
-		current = next
+			current = next
+		}
 	}
+
+	replace(node)
 }


### PR DESCRIPTION
This pull request implements nested callouts. Test cases added to ensure nested callouts and blockquotes inside nested callouts work.

Here is a sample rendering I've generated using this new code:

<img width="1337" height="499" alt="nested_callout" src="https://github.com/user-attachments/assets/93dbd0a7-3352-4fc5-a796-71ac78ed98c9" />

And with a blockquote inside the nested callout:

<img width="1337" height="652" alt="nested_callout_with_blockquote" src="https://github.com/user-attachments/assets/e67e9917-34bb-4ea8-8b11-5512d1cf71be" />
